### PR TITLE
Added function to read nf-core/eager input .tsv for additional library information

### DIFF
--- a/Autorun_multiqc_stats_collect/collect_results.py
+++ b/Autorun_multiqc_stats_collect/collect_results.py
@@ -202,17 +202,17 @@ def files_are_consistent(mqc_data, mqc_html, skip_check=False):
         return skip_check
     return True
 
-def read_eager_input_table(prompt):
+def read_eager_input_table(file_path):
     '''
     Creates dictionaries with all the possible combinations of the columns in the given file.
     '''
-    l = prompt.readlines()
+    l = file_path.readlines()
     headers = l[0].strip().split('\t')
     return map(lambda row: dict(zip(headers, row.split('\t'))), l[1:])
 
 import glob
 
-def dict_data():
+def dict_data(path='./', columns=[]):
     '''
     Asks for input from the user. The input should be a directory for a folder and any number of the words from 
         the allowed_word list.
@@ -233,30 +233,23 @@ def dict_data():
     If the user provides multiple words, a dictionary will be created for each of the corresponding columns.
     '''
     allowed_words = {"Sample_Name", "Lane", "Colour_Chemistry", "SeqType", "Organism", "Strandedness", 
-                     "UDG_Treatment", "R1", "R2", "BAM"}
-    folder_path = input().strip()
-    column = input().strip().split()
-    if all(word in allowed_words for word in column):
-        pattern = folder_path + '\\*.tsv'
+                        "UDG_Treatment", "R1", "R2", "BAM"}
+    if all(word in allowed_words for word in columns):
+        pattern = path + '*.tsv'
         p = glob.glob(pattern)
         print(pattern) # Prints the whole of the provided pattern. Helpful to identify a problem caused by problematic directory input
         asked_dict = {}
-
         if not p:
             print("No .tsv files found in the specified folder.") # Returns an error message if there is an issue with the creation of p
             return
         
-        asked_dict = [{} for _ in column]  # Create a list of empty dictionaries for each requested column
-
+        asked_dict = [{} for _ in columns]  # Create a list of empty dictionaries for each requested column
         for file_path in p:
-
             with open(file_path, 'r') as f: 
                     for row in read_eager_input_table(f): # Calls the above function
-
                         if "Library_ID" in row: # This part could be skipped but eh, whatever
-                           
                             key = row["Library_ID"]
-                            for idx, col in enumerate(column):
+                            for idx, col in enumerate(columns):
                                 asked_dict[idx][key] = row[col]
                             
         print(asked_dict)

--- a/Autorun_multiqc_stats_collect/collect_results.py
+++ b/Autorun_multiqc_stats_collect/collect_results.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 import os
 
-VERSION = "1.2.0"
+VERSION = "1.3.0"
 
 
 def get_individual_library_stats(mqc_data):

--- a/Autorun_multiqc_stats_collect/collect_results.py
+++ b/Autorun_multiqc_stats_collect/collect_results.py
@@ -202,6 +202,65 @@ def files_are_consistent(mqc_data, mqc_html, skip_check=False):
         return skip_check
     return True
 
+def read_eager_input_table(prompt):
+    '''
+    Creates dictionaries with all the possible combinations of the columns in the given file.
+    '''
+    l = prompt.readlines()
+    headers = l[0].strip().split('\t')
+    return map(lambda row: dict(zip(headers, row.split('\t'))), l[1:])
+
+import glob
+
+def dict_data():
+    '''
+    Asks for input from the user. The input should be a directory for a folder and any number of the words from 
+        the allowed_word list.
+    
+    A \\*.tsv is always added automatically at the end of the given directory, so that only .tsv files 
+        will be searched for, but it should also be taken into consideration when providing the directory 
+        for the folder by the user.
+    
+    All of the .tsv files in the folder are read.
+
+    This function calls the function above to create a dictionary out of the .tsv files of the given folder 
+        and then prints a list with all the requested dictionaries (could be just one or could be multiple).
+
+    The requested dictionary will always have as keys the data from the Library_ID column of the .tsv files 
+        and as correspoding values the data of the column which titled with the word provided by the user
+        (one of the words in the allowed_word list).
+
+    If the user provides multiple words, a dictionary will be created for each of the corresponding columns.
+    '''
+    allowed_words = {"Sample_Name", "Lane", "Colour_Chemistry", "SeqType", "Organism", "Strandedness", 
+                     "UDG_Treatment", "R1", "R2", "BAM"}
+    folder_path = input().strip()
+    column = input().strip().split()
+    if all(word in allowed_words for word in column):
+        pattern = folder_path + '\\*.tsv'
+        p = glob.glob(pattern)
+        print(pattern) # Prints the whole of the provided pattern. Helpful to identify a problem caused by problematic directory input
+        asked_dict = {}
+
+        if not p:
+            print("No .tsv files found in the specified folder.") # Returns an error message if there is an issue with the creation of p
+            return
+        
+        asked_dict = [{} for _ in column]  # Create a list of empty dictionaries for each requested column
+
+        for file_path in p:
+
+            with open(file_path, 'r') as f: 
+                    for row in read_eager_input_table(f): # Calls the above function
+
+                        if "Library_ID" in row: # This part could be skipped but eh, whatever
+                           
+                            key = row["Library_ID"]
+                            for idx, col in enumerate(column):
+                                asked_dict[idx][key] = row[col]
+                            
+        print(asked_dict)
+
 def main():
     ## Column order same as old script.
     output_columns = {


### PR DESCRIPTION
Added function to read .tsv table and return a dictionary with the requested values.

Please fill in the checklist below. These are the minimum requirements for helper scripts.
## PR checklist

 - [x] This comment contains a description of changes (with reason). What script you are adding and what it does (in two lines tops).
 - [x] Helper script is in a dedicated subdirectory.
 - [x] Make sure your tool directory includes a `README.md`.
 - [x] Your helper script should:
   - [ ] Be executable.
   - [ ] Accept any required inputs through the command line. No copying/editing scripts should be necessary for use.
   - [ ] Have a version number that follows [semantic versioning](https://semver.org/).
   - [ ] Include CLI options `-v` and `--version` which print the version number and exit.
 - [x] The `README.md` should include:
   - [ ] a short example of any required input files, to showcase the expected format.
   - [ ] an example command, to showcase how the script should be called. This command does not need to be a real command, so paths can be to dummy file names.

Once you confirm all the requirements above are fulfilled, you can request a PR review! :)
