### PR TITLE
collect_results.py 1.6.3

### DIFF
--- a/Autorun_multiqc_stats_collect/CHANGELOG.md
+++ b/Autorun_multiqc_stats_collect/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to collect_results.py will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.6.3 - 2026-01-28
+## 1.6.3 - 2026-04-06
 
 ### Added
 
 ### Fixed
 
 - Fixed an issue where the script would crash is certain results were at the sample level, instead of the library level. This happened when a udg merging step was needed, but no sample-level merge.
+- Fixed a bug where the SNP coverage stats were not picked up correctly in cases where nuclear contamination failed for a library.
+- Made debugging in an interactive session a bit easier.
 
 ### Removed
 

--- a/Autorun_multiqc_stats_collect/CHANGELOG.md
+++ b/Autorun_multiqc_stats_collect/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to collect_results.py will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.6.3 - 2026-01-28
+
+### Added
+
+### Fixed
+
+- Fixed an issue where the script would crash is certain results were at the sample level, instead of the library level. This happened when a udg merging step was needed, but no sample-level merge.
+
+### Removed
+
 ## 1.6.2 - 2026-01-14
 
 ### Added

--- a/Autorun_multiqc_stats_collect/collect_results.py
+++ b/Autorun_multiqc_stats_collect/collect_results.py
@@ -652,7 +652,9 @@ def main():
             f"## Command: {parser.prog} -i {args.input} -o {args.output} -a {args.analysis_type}{flags}",
             file=f,
         )
+        ## Return collected datasets for easier debugging.
+        return (main_id_dict, collected_stats)
 
 
 if __name__ == "__main__":
-    main()
+    main_id_dict, collected_stats = main()

--- a/Autorun_multiqc_stats_collect/collect_results.py
+++ b/Autorun_multiqc_stats_collect/collect_results.py
@@ -30,7 +30,7 @@ except ImportError:
     )
     import pyPandoraHelper as pH
 
-VERSION = "1.6.3"
+VERSION = "1.6.3-beta2"
 
 
 def get_individual_library_stats(
@@ -223,17 +223,17 @@ def standardise_column_names(collected_stats):
         new_stats = collected_stats[library]
         new_stats.update(new_attributes)  ## Add all new attributed with NAs
         ## Deal with older versions of multiqc
-        try:
-            for name, old_name in old_names.items():
+        for name, old_name in old_names.items():
+            try:
                 new_stats[name] = new_stats[old_name]
-        except KeyError:
-            pass
+            except KeyError:
+                continue
         ## Deal with newer versions of multiqc
-        try:
-            for name, new_name in new_names.items():
+        for name, new_name in new_names.items():
+            try:
                 new_stats[name] = new_stats[new_name]
-        except KeyError:
-            pass
+            except KeyError:
+                continue
         # print("library:", library, "stats", new_stats, sep="\n")
         collected_stats[library] = new_stats
     return collected_stats

--- a/Autorun_multiqc_stats_collect/collect_results.py
+++ b/Autorun_multiqc_stats_collect/collect_results.py
@@ -30,7 +30,7 @@ except ImportError:
     )
     import pyPandoraHelper as pH
 
-VERSION = "1.6.2"
+VERSION = "1.6.3"
 
 
 def get_individual_library_stats(
@@ -74,9 +74,26 @@ def get_individual_library_stats(
             #         library_stats[key] = data["report_saved_raw_data"]["multiqc_general_stats"][key]
             #     sample_libraries.append(key)  ## Keep track of library IDs for later
         else:
-            sample_stats[key] = data["report_saved_raw_data"]["multiqc_general_stats"][
-                key
-            ]
+            ## 28-01-2026: There are cases where the _udg flag is present at the sample level as well
+            ## We need to deal with this edge case as well, and put the results into the sample level.
+            if len(key.split("_udg")) > 1:
+                try:
+                    sample_stats[key.split("_udg")[0]].update(
+                        data["report_saved_raw_data"]["multiqc_general_stats"][key]
+                    )
+                except KeyError:
+                    sample_stats[key.split("_udg")[0]] = data["report_saved_raw_data"][
+                        "multiqc_general_stats"
+                    ][key]
+            else:
+                try:
+                    sample_stats[key].update(
+                        data["report_saved_raw_data"]["multiqc_general_stats"][key]
+                    )
+                except KeyError:
+                    sample_stats[key] = data["report_saved_raw_data"][
+                        "multiqc_general_stats"
+                    ][key]
     ## Add the same data type (analysis type) to all sample stats
     for key in sample_stats.keys():
         sample_stats[key]["Data_type"] = data_type

--- a/Autorun_multiqc_stats_collect/collect_results.py
+++ b/Autorun_multiqc_stats_collect/collect_results.py
@@ -30,7 +30,7 @@ except ImportError:
     )
     import pyPandoraHelper as pH
 
-VERSION = "1.6.3-beta2"
+VERSION = "1.6.3"
 
 
 def get_individual_library_stats(


### PR DESCRIPTION
Fixed an issue where the script would crash is certain results were at the sample level, instead of the library level.
Fixed a bug where coverage stats were not pulled correctly when nuclear contamination results were missing.
Minor changes to aid in debugging.

Many thanks to contributing to MPI-EVA-Archaeogenetics/helper_scripts!

Please fill in the checklist below. These are the minimum requirements for helper scripts.
## PR checklist

 - [x] This comment contains a description of changes (with reason). What script you are adding and what it does (in two lines tops).
 - [x] Helper script is in a dedicated subdirectory.
 - [x] Make sure your tool directory includes a `README.md`.
 - [x] Your helper script should:
   - [ ] Be executable.
   - [ ] Accept any required inputs through the command line. No copying/editing scripts should be necessary for use.
   - [ ] Have a version number that follows [semantic versioning](https://semver.org/).
   - [ ] Include CLI options `-v` and `--version` which print the version number and exit.
 - [x] The `README.md` should include:
   - [ ] a short example of any required input files, to showcase the expected format.
   - [ ] an example command, to showcase how the script should be called. This command does not need to be a real command, so paths can be to dummy file names.

Once you confirm all the requirements above are fulfilled, you can request a PR review! :)
